### PR TITLE
arm_sdimage.sh support for Ubuntu 14.04

### DIFF
--- a/releasetools/arm_sdimage.sh
+++ b/releasetools/arm_sdimage.sh
@@ -136,10 +136,12 @@ then
 	fi
 fi
 
+
+rm -rf ${OBJ_DIR}
 #
 # Artifacts from this script are stored in the IMG_DIR
 #
-rm -rf ${IMG_DIR}
+# rm -rf ${IMG_DIR}
 
 if [ -f ${IMG} ]	# IMG might be a block device
 then	rm -f ${IMG}


### PR DESCRIPTION
Running arm_sdimage.sh without installing zlib or other other packages found here: http://wiki.minix3.org/doku.php?id=developersguide:crosscompiling corrupts OBJ_DIR for subsequent attempts.